### PR TITLE
Add: exit builtin with a status code

### DIFF
--- a/builtins.c
+++ b/builtins.c
@@ -3,16 +3,33 @@
 /**
  * handle_exit - handles the exit built-in
  * @args: the command and its arguments
+ * @argv: NULL terminated list of the shell's arguments
  *
  * Return: nothing
 */
-void handle_exit(char **args)
+void handle_exit(char **args, char **argv)
 {
-	if (args[1] == NULL)
+	int exit_code = 0;
+
+	if (args[1])
 	{
-		free_tokens(args);
-		exit(EXIT_SUCCESS);
+		exit_code = _atoi(args[1]);
+		if (exit_code < 0)
+		{
+			exit_code = 2;
+			write(STDOUT_FILENO, argv[0], _strlen(argv[0]));
+			write(STDOUT_FILENO, ": 1: ", 5);
+			write(STDOUT_FILENO, args[0], _strlen(args[0]));
+			write(STDOUT_FILENO, ": ", 2);
+			write(STDOUT_FILENO, "Illegal number: ", 16);
+			write(STDOUT_FILENO, args[1], _strlen(args[1]));
+			write(STDOUT_FILENO, "\n", 1);
+		}
+		else if (exit_code > 255)
+			exit_code = 255;
 	}
+	free_tokens(args);
+	exit(exit_code);
 }
 
 /**

--- a/core.c
+++ b/core.c
@@ -68,7 +68,7 @@ char *search_prog(char *command, char **tokens, char *argv[])
 
 	if (!tokens || !env_path)
 		return (NULL);
-	if (execute_builtin_command(command, tokens, env_path))
+	if (execute_builtin_command(command, tokens, env_path, argv))
 	{
 		return (NULL);
 	}

--- a/execute_command.c
+++ b/execute_command.c
@@ -6,11 +6,13 @@
  * @command: command given by user
  * @args: null-terminate array of strings containing command and its arguments
  * @env_path: pointer to the path of the environment
+ * @argv: NULL terminated list of the shell's arguments
  *
  * Return: 1 success, 0 otherwise
  */
 
-int execute_builtin_command(char *command, char **args, char *env_path)
+int execute_builtin_command(char *command,
+char **args, char *env_path, char **argv)
 {
 	char *cmd = args[0];
 	char error_message[100];
@@ -21,7 +23,7 @@ int execute_builtin_command(char *command, char **args, char *env_path)
 	{
 		free(env_path);
 		free(command);
-		handle_exit(args);
+		handle_exit(args, argv);
 		return (1);
 	}
 	if (_strcmp(cmd, "cd") == 0)
@@ -42,6 +44,7 @@ int execute_builtin_command(char *command, char **args, char *env_path)
 	}
 	if (_strcmp(cmd, "env") == 0)
 	{
+		free(env_path);
 		handle_env();
 		return (1);
 	}

--- a/main.c
+++ b/main.c
@@ -96,8 +96,9 @@ void shell_loop(char **env, char *argv[])
 *
 * Return: 0 if successful, non-zero if error
 */
-int main(UN_ATTR int argc, char **argv, char **env)
+int main(int argc, char **argv, char **env)
 {
+	(void)argc;
 	last_exit_status = 0;
 	shell_loop(env, argv);
 

--- a/shell.h
+++ b/shell.h
@@ -30,6 +30,7 @@ typedef struct directory_list
 	struct directory_list *next;
 } dir_l;
 
+
 void set_last_exit_status(int status);
 int get_last_exit_status(void);
 size_t _strlen(const char *str);
@@ -47,7 +48,8 @@ void free_dirl(dir_l **head);
 char *searchfile(dir_l *head, char *name);
 char *search_prog(char *command, char **tokens, char **argv);
 void upd_cmd(char ***args, char *str, int ntoks, size_t str_len, char *name);
-int execute_builtin_command(char *command, char **args, char *env_path);
+int execute_builtin_command(char *command, char **args,
+char *env_path, char **argv);
 int execute_external_command(char **args, char **env);
 int execute_command(char **args, char **env);
 char *_memcpy(char *dest, char *src, unsigned int n);
@@ -69,7 +71,7 @@ void cleanup(char *command, char **args, char *progPath);
 int _atoi(const char *str);
 void handle_sigint(int sig);
 void showError(char *program, char *command);
-void handle_exit(char **args);
+void handle_exit(char **args, char **argv);
 void handle_env(void);
 
 #endif /* #ifndef __SHELL__H_ */


### PR DESCRIPTION
* Handled memory cleanup after executing the `env` command.
* Added functionality to exit the shell using the exit command together with a status code as the argument.